### PR TITLE
Command rename and added block details

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://tezster.s3-ap-southeast-1.amazonaws.com/TEZSTER_CLI/1_jDB5enULQVo2UfeiwD32qA.png" alt="Tezster CLI banner" align="center" />
 <div align="center"><strong>A complete toolbox to build, deploy and interact with the applications on Tezos sandbox and Tezos testnets.</strong></div>
-<div align="center">Tezster-CLI comes in an npm package with a set of easy commands to kickstart the development or interaction with Tezos blockchain. It allows you to interact with local nodes as well as remote testnet nodes and deploy or call smart contracts. To get complete understanding of components usage and visual demo follow <a href="https://docs.tezster.tech/tezster-cli"><strong>Tezster-CLI Guide</strong></a>.
+<div align="center">Tezster-CLI comes in an npm package with a set of easy commands to kickstart the development or interaction with Tezos blockchain. It allows you to interact with local nodes as well as remote testnet nodes and deploy or call smart contracts. To get complete understanding of components usage and visual demo follow <a href="https://docs.cli.tezster.tech/"><strong>Tezster-CLI Guide</strong></a>.
 </div>
 
 # Getting Started
@@ -38,7 +38,7 @@ For Ubuntu/Linux run :  ```sudo apt install docker.io``` <br />
 For Debian refer this [link](https://docs.docker.com/engine/install/debian/). <br />
 For MAC refer this [link](https://docs.docker.com/docker-for-mac/release-notes/#docker-desktop-community-2303). (Docker Desktop stable v2.3.0.2 or later) <br />
 
-*Note: If you are using **windows**, please follow docker installation steps as detailed in [docker installation steps for windows](https://docs.tezster.tech/tezster-cli#docker-installation-steps-for-windows).*
+*Note: If you are using **windows**, please follow docker installation steps as detailed in [docker installation steps for windows](https://docs.cli.tezster.tech/getting-started/prerequisites#docker-installation-for-windows).*
 
 ### Post Docker Installation Guide (Skip if using windows or docker-desktop)
 Make sure after installing docker you have added $USER to the docker group, if not run the following commands:
@@ -78,7 +78,7 @@ To list down all the tezster commands, run:
 tezster --help
 ```
 
-Congratulations, you are all set to use Tezster-CLI commands. For usage guidance follow our **[documentation page](https://docs.tezster.tech/tezster-cli#playground-setup)**.
+Congratulations, you are all set to use Tezster-CLI commands. For usage guidance follow our **[documentation page](https://docs.cli.tezster.tech/playgrouns-setup/local-tezos-nodes)**.
 
 
 ## Contributing
@@ -90,7 +90,7 @@ There are many ways to contribute, from writing tutorials or blog posts, improvi
 
 ### Reporting bugs and Support
 
-To know about common errors and fixes follow our [common errors](https://docs.tezster.tech/tezster-cli#common-errors-with-possible-fix). To report bugs, please create an issue on [issue page](https://github.com/Tezsure/Tezster-CLI/issues).
+To know about common errors and fixes follow our [common errors](https://docs.cli.tezster.tech/common-errors/common-errors-with-possible-fix). To report bugs, please create an issue on [issue page](https://github.com/Tezsure/Tezster-CLI/issues).
 
 **You can get in touch with us for any open discussion and 24*7 support via [Telegram](https://t.me/tezster).**
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Follow below steps to get started with Tezster-CLI.
 
 ## Prerequisites
 
-1. Node v. 12.x+
+1. Node v. 12.x.x
 2. Docker v. 2.3.0.2+
+
+*Note: We recommend to install Node LTS version i.e. 12.x.x.*
 
 ### OS Support
 1. Linux (Ubuntu and Debian)

--- a/modules/accounts/accounts.js
+++ b/modules/accounts/accounts.js
@@ -17,12 +17,12 @@ class Accounts{
     }
 
     async setProvider(args){
-        Logger.verbose(`Command : tezster set-provider ${args}`);
+        Logger.verbose(`Command : tezster set-rpc-node ${args}`);
         this.setProviderAccounts(args.newNodeProvider);
     }
 
     async getProvider() {
-        Logger.verbose(`Command : tezster get-provider`);
+        Logger.verbose(`Command : tezster get-rpc-node`);
         this.getProviderAccounts();
     }
 
@@ -107,14 +107,14 @@ class Accounts{
         }
 
         jsonfile.writeFile(confFile, config);
-        Logger.info('Provider updated to ' + config.provider);
+        Logger.info('Active RPC node updated to ' + config.provider);
     }
 
     getProviderAccounts(){    
         if (config.provider) {
             Logger.info(config.provider);
         } else {
-            Logger.warn('No provider is set');
+            Logger.warn('No rpc node is set');
         } 
     }
 
@@ -233,7 +233,7 @@ class Accounts{
         }
 
         if(Helper.confirmNodeProvider(tezosNode)) {
-            Logger.error('Make sure your current provider is set to remote node provider.');
+            Logger.error('Make sure your current rpc-node is set to remote node.');
             return;
         }
 

--- a/modules/cli-constants.js
+++ b/modules/cli-constants.js
@@ -21,11 +21,14 @@ const confFile = `/var/tmp/tezster/config.json`,
       START_NODES_PROGRESS_BAR_INTERVAL_WIN = 0.80,
       LOCAL_NODE_URL = 'http://localhost:18731',
       WIN_OS_PLATFORM = 'win32',
-      WIN_WSL_OS_RELEASE = 'microsoft'; 
+      WIN_WSL_OS_RELEASE = 'microsoft',
+      TZSTAT_BLOCK_HEAD_API = `https://api.carthagenet.tzstats.com/explorer/block/head/op`,
+      TZSTAT_BLOCK_CHAIN_CONFIG_API = `https://api.carthagenet.tzstats.com/explorer/config/head`; 
 
 module.exports = { confFile, CONSEIL_JS, TESTNET_NAME, CONSEIL_SERVER_APIKEY, TEZSTER_LOGS_FOLDER_PATH,
                    IMAGE_TAG, CONTAINER_NAME, LOCAL_NODE_URL, CONSEIL_SERVER_URL, COMMAND_LOG_FILE, TEMP_PATH,
                    PROGRESS_REFRESH_INTERVAL, TEZSTER_FOLDER_PATH, START_NODES_PROGRESS_BAR_INTERVAL_WIN,
                    LOGS_ZIPFILE_PATH, LOG_FOLDER_PATH_INSIDE_DOCKER, LOGS_ZIPFILE_NAME,
                    CONFIG_FILE_ABSOLUTE_PATH_INSIDE_NPM_PACKAGE, WIN_OS_PLATFORM, WIN_WSL_OS_RELEASE,
-                   NODE_CONFIRMATION_TIMEOUT_WIN, Node_Confirmation_Timeout, Start_Nodes_Progress_Bar_Interval };
+                   NODE_CONFIRMATION_TIMEOUT_WIN, Node_Confirmation_Timeout, Start_Nodes_Progress_Bar_Interval,
+                   TZSTAT_BLOCK_HEAD_API, TZSTAT_BLOCK_CHAIN_CONFIG_API };

--- a/modules/exceptionHandler.js
+++ b/modules/exceptionHandler.js
@@ -4,14 +4,14 @@ const Logger = require('./logger'),
 const EMPTY_IMPLICIT_CONTRACT = 'Account is not yet revealed on the blockchain. You can reveal the account by sending some tezos to the account.',
       EMPTY_TRANSACTION = `Make sure current network is same as the network smart contract got deployed....`,
       NOT_FOUND_404 = `Make sure current network is same as the network smart contract got deployed....`,
-      CONNECT_ECONNREFUSED = 'Error occurred while establishing the connection with node provider....',
-      ABSOLUTE_URL_ARE_SUPPORTED = 'Current provider URL is not supported by network provider....',
-      GETADDRINFO = 'Current provider URL is not supported by network provider....',
-      HTTP_PROTOCOL = 'Current provider URL is not supported by network provider....',
-      CANNOT_READ_PROPERTY = 'Current provider URL is not supported by network provider....',
+      CONNECT_ECONNREFUSED = 'Error occurred while establishing the connection with rpc-node....',
+      ABSOLUTE_URL_ARE_SUPPORTED = 'Current rpc-node URL is not supported by the network....',
+      GETADDRINFO = 'Current rpc-node URL is not supported by the network....',
+      HTTP_PROTOCOL = 'Current rpc-node URL is not supported by  the network....',
+      CANNOT_READ_PROPERTY = 'Current rpc-node URL is not supported by the network....',
       CHECKSUM = `Account doesn't  exists or not revealed on the network.... To list down all accounts run 'tezster list-accounts'.`,
-      INVALID = 'Current provider URL is not supported by network provider....',
-      UNEXPECTED_END_OF_JSON_INPUT = 'Make sure account is revealed on the current provider....';
+      INVALID = 'Current rpc-node URL is not supported by the network....',
+      UNEXPECTED_END_OF_JSON_INPUT = 'Make sure account is revealed on the current rpc-node....';
 
 class ExceptionHandler {
 

--- a/modules/setup/setup.js
+++ b/modules/setup/setup.js
@@ -108,7 +108,7 @@ class Setup {
     async nodeStatus() {
         Logger.verbose('Command : tezster node-status');
 
-        if(config.provider.includes('localhost')) {
+        if(config.provider.includes('localhost') || config.provider.includes('192.168')) {
             try {
                 let response = await RpcRequest.checkNodeStatusForLocalNodes(LOCAL_NODE_URL);
                 if(response.protocol.startsWith('PsCARTHAG')){

--- a/tezster.js
+++ b/tezster.js
@@ -28,14 +28,15 @@ program
 
 /******* To start local tezos nodes on user system*/
 program.command('start-nodes')
-    .description('Starts Tezos nodes')
+    .description(`Starts local Tezos nodes`)
     .action(function(){  
         tezstermanager.startNodes();
 });
 
 /******* To stop local tezos nodes on user system*/
 program.command('stop-nodes')
-    .description('Stops Tezos nodes')
+    .usage(`\n(This command provides the interactive shell)`)
+    .description(`Stops local Tezos nodes`)
     .action(function() {
         if (process.argv.length > 3) {
             console.log('Incorrect usage of stop-nodes command. Correct usage: - tezster stop-nodes');
@@ -58,6 +59,7 @@ program.command('node-status')
 /******* To set the rpc-node */
 program
     .command('set-rpc-node')
+    .usage(`\n(This command provides the interactive shell)`)
     .description('To change the default rpc node provider')
     .action(function() {
         if (process.argv.length > 3) {
@@ -150,6 +152,7 @@ program
 /*******deploy contract written in Michelson*/
 program
     .command('deploy')
+    .usage(`\n(This command provides the interactive shell)`)
     .description('Deploys a smart contract written in Michelson')
     .action(function() {
         if (process.argv.length > 3) {
@@ -165,6 +168,7 @@ program
 /*******calls contract written in Michelson*/
 program
     .command('call')
+    .usage(`\n(This command provides the interactive shell)`)
     .description('Calls a smart contract with given value provided in Michelson format')
     .action(function() {
         if (process.argv.length > 3) {

--- a/tezster.js
+++ b/tezster.js
@@ -55,13 +55,13 @@ program.command('node-status')
         tezstermanager.nodeStatus();
 });
 
-/******* To set the Provider */
+/******* To set the rpc-node */
 program
-    .command('set-provider')
-    .description('To change the default provider')
+    .command('set-rpc-node')
+    .description('To change the default rpc node provider')
     .action(function() {
         if (process.argv.length > 3) {
-            console.log('Incorrect usage of set-provider command. Correct usage: - tezster set-provider');
+            console.log('Incorrect usage of set-rpc-node command. Correct usage: - tezster set-rpc-node');
             return;
         }
         prompt(accountSetProviderParameters).then(accountSetProviderParameterValues => {
@@ -69,10 +69,10 @@ program
         });
 });
 
-/******* To get the Provider */
+/******* To get the current rpc-node */
 program
-    .command('get-provider')
-    .description('To fetch the current provider')
+    .command('get-rpc-node')
+    .description('To fetch the current rpc node')
     .action(function(){        
         tezstermanager.getProvider();
 });
@@ -253,8 +253,8 @@ const validCommands = [
     'stop-nodes',
     'node-status',
     'get-logs',
-    'get-provider',
-    'set-provider',
+    'get-rpc-node',
+    'set-rpc-node',
     'transfer',
     'get-balance',
     'list-entry-points', 

--- a/utils/account.setProvider.parameters.js
+++ b/utils/account.setProvider.parameters.js
@@ -2,7 +2,7 @@ const accountSetProviderParameters = [
     {
       type : 'list',
       name : 'newNodeProvider',
-      message : 'Select new node provider: ',
+      message : 'Select new rpc-node: ',
       choices: ['http://localhost:18731', 'https://testnet.tezster.tech', 'https://tezos-dev.cryptonomic-infra.tech', 'https://carthagenet.SmartPy.io']
     },
 ];


### PR DESCRIPTION
What's new:
- modified node-status command, now showing block and cycle related details
- rename set/get-provider --> set/get-rpc-node